### PR TITLE
Use a custom parser function instead of markdown

### DIFF
--- a/stringify_plugin.py
+++ b/stringify_plugin.py
@@ -3,11 +3,23 @@
 
 import re
 from telethon import events
+from telethon.utils import add_surrogate
+from telethon.tl.types import MessageEntityPre
 from .global_functions import log
+
+
+def parse_pre(text):
+    """Custom parser that turns an entire message into a pre block"""
+    text = text.strip()
+    return (
+        text,
+        [MessageEntityPre(offset=0, length=len(add_surrogate(text)), language="")]
+    )
+
 
 @events.register(events.NewMessage(pattern=r"(?s)^(?!/(start|ping|help))(.+)?$", outgoing=False))
 async def stringfy_message(event):
     if event.is_private:
         replied_msg = re.sub(r"(?<=.{100}).+", "...'", event.message.stringify())
-        await event.reply(f"```{replied_msg}```")
+        await event.reply(replied_msg, parse_mode=parse_pre)
         await log(event)


### PR DESCRIPTION
This fixes being able to break formatting by putting ``` in a message